### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/cricbuzz.el
+++ b/cricbuzz.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'enlive)
+(require 'org)
 
 (defvar cricbuzz-base-url "http://cricbuzz.com")
 (defvar cricbuzz-live-url (concat cricbuzz-base-url "/cricket-match/live-scores"))
@@ -59,7 +60,7 @@
    "<%Y-%m-%d %a %H:%M>"
    (seconds-to-time
     (/
-     (string-to-int
+     (string-to-number
       (enlive-attr (first (enlive-get-elements-by-class-name match-node "schedule-date")) 'timestamp))
      1000))))
 


### PR DESCRIPTION
- Load org for using its functions
- Don't use obsoleted function

There are following byte-compile warnings.

```
In cricbuzz-get-time:
cricbuzz.el:60:5:Warning: ‘string-to-int’ is an obsolete function (as of
    22.1); use ‘string-to-number’ instead.

In cricbuzz-get-live-scores:
cricbuzz.el:155:19:Warning: reference to free variable ‘org-agenda-files’
cricbuzz.el:155:19:Warning: assignment to free variable ‘org-agenda-files’

In end of data:
cricbuzz.el:338:1:Warning: the following functions are not known to be defined: org-todo,
    org-set-property, org-table-next-field, org-table-create,
    org-table-insert-hline, org-table-next-row, org-table-align,
    org-get-property-block
```
